### PR TITLE
Add static generation to posts pages

### DIFF
--- a/app/[locale]/posts/[slug]/page.tsx
+++ b/app/[locale]/posts/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { baseUrl } from 'app/sitemap'
 import { findPostBySlugAndLocale } from '../utils'
 import { allPosts } from 'contentlayer/generated'
 
+
 type Props = {
   params: Promise<{ slug: string, locale: string }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
@@ -99,3 +100,5 @@ export default async function Blog({ params }: Props ) {
     </section>
   )
 }
+
+export const dynamic = 'force-static'

--- a/app/[locale]/posts/page.tsx
+++ b/app/[locale]/posts/page.tsx
@@ -3,6 +3,7 @@ import { getLocale, getTranslations } from 'next-intl/server';
 import { allPosts } from 'contentlayer/generated'
 import { compareDesc } from 'date-fns'
 
+export const dynamic = 'force-static'
 
 // export async function generateStaticParams() {
 //   return [


### PR DESCRIPTION
This pull request includes changes to the `app/[locale]/posts/[slug]/page.tsx` and `app/[locale]/posts/page.tsx` files to ensure that the pages are statically generated. The most important changes include adding the `dynamic` export to both files.

Changes to static generation:

* `app/[locale]/posts/[slug]/page.tsx`: Added `export const dynamic = 'force-static'` to enforce static generation for the blog post page. ([app/[locale]/posts/[slug]/page.tsxR103-R104](diffhunk://#diff-203bcce97502117e7dc7895044a544942f621c6e03b9d223aa3ecc5a98b083e9R103-R104))
* `app/[locale]/posts/page.tsx`: Added `export const dynamic = 'force-static'` to enforce static generation for the posts listing page. ([app/[locale]/posts/page.tsxR6](diffhunk://#diff-ae6fe0b7a0e65b12b2f5f087e448cd504215fc43b8a45d4ee00ec875f42405fbR6))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the static rendering configuration for blog posts and posts listing pages to ensure consistent content delivery. These adjustments enforce a uniform static generation approach, which may enhance reliability and load performance for end-users while keeping core functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->